### PR TITLE
Properly Catch RefsExistError on ressource creation

### DIFF
--- a/neutron_plugin_contrail/plugins/opencontrail/contrailplugin.py
+++ b/neutron_plugin_contrail/plugins/opencontrail/contrailplugin.py
@@ -361,6 +361,8 @@ class ContrailPlugin(db_base_plugin_v2.NeutronDbPluginV2,
 
             LOG.debug("create_subnet(): " + pformat(subnet_dict))
             return subnet_dict
+        except RefsExistError as e:
+            raise exc.BadRequest(resource='subnet', msg=str(e))
         except Exception as e:
             cgitb.Hook(format="text").handle(sys.exc_info())
             raise e
@@ -468,6 +470,8 @@ class ContrailPlugin(db_base_plugin_v2.NeutronDbPluginV2,
 
             LOG.debug("create_ipam(): " + pformat(ipam_dict))
             return ipam_dict
+        except RefsExistError as e:
+            raise exc.BadRequest(resource='ipam', msg=str(e))
         except Exception as e:
             cgitb.Hook(format="text").handle(sys.exc_info())
             raise e
@@ -576,6 +580,8 @@ class ContrailPlugin(db_base_plugin_v2.NeutronDbPluginV2,
 
             LOG.debug("create_policy(): " + pformat(policy_dict))
             return policy_dict
+        except RefsExistError as e:
+            raise exc.BadRequest(resource='policy', msg=str(e))
         except Exception as e:
             cgitb.Hook(format="text").handle(sys.exc_info())
             raise e
@@ -703,6 +709,8 @@ class ContrailPlugin(db_base_plugin_v2.NeutronDbPluginV2,
 
             LOG.debug("create_router(): " + pformat(router_dict) + "\n")
             return router_dict
+        except RefsExistError as e:
+            raise exc.BadRequest(resource='router', msg=str(e))
         except Exception as e:
             cgitb.Hook(format="text").handle(sys.exc_info())
             raise e
@@ -860,6 +868,8 @@ class ContrailPlugin(db_base_plugin_v2.NeutronDbPluginV2,
 
             LOG.debug("create_floatingip(): " + pformat(fip_dict))
             return fip_dict
+        except RefsExistError as e:
+            raise exc.BadRequest(resource='floatingip', msg=str(e))
         except Exception as e:
             cgitb.Hook(format="text").handle(sys.exc_info())
             raise e
@@ -962,6 +972,8 @@ class ContrailPlugin(db_base_plugin_v2.NeutronDbPluginV2,
 
             LOG.debug("create_port(): " + pformat(port_dict))
             return port_dict
+        except RefsExistError as e:
+            raise exc.BadRequest(resource='port', msg=str(e))
         except Exception as e:
             cgitb.Hook(format="text").handle(sys.exc_info())
             raise e
@@ -1119,6 +1131,8 @@ class ContrailPlugin(db_base_plugin_v2.NeutronDbPluginV2,
             rt_dict.update(rt_info['q_extra_data'])
             LOG.debug("create_route_table(): " + pformat(rt_dict))
             return rt_dict
+        except RefsExistError as e:
+            raise exc.BadRequest(resource='route_table', msg=str(e))
         except Exception as e:
             cgitb.Hook(format="text").handle(sys.exc_info())
             raise e
@@ -1212,6 +1226,8 @@ class ContrailPlugin(db_base_plugin_v2.NeutronDbPluginV2,
 
             LOG.debug("create_nat_instance(): " + pformat(si_dict))
             return si_dict
+        except RefsExistError as e:
+            raise exc.BadRequest(resource='nat_instance', msg=str(e))
         except Exception as e:
             cgitb.Hook(format="text").handle(sys.exc_info())
             raise e
@@ -1303,6 +1319,8 @@ class ContrailPlugin(db_base_plugin_v2.NeutronDbPluginV2,
 
             LOG.debug("create_security_group(): " + pformat(sg_dict))
             return sg_dict
+        except RefsExistError as e:
+            raise exc.BadRequest(resource='security_group', msg=str(e))
         except Exception as e:
             cgitb.Hook(format="text").handle(sys.exc_info())
             raise e
@@ -1392,6 +1410,8 @@ class ContrailPlugin(db_base_plugin_v2.NeutronDbPluginV2,
 
             LOG.debug("create_security_group_rule(): " + pformat(sgr_dict))
             return sgr_dict
+        except RefsExistError as e:
+            raise exc.BadRequest(resource='security_group_rule', msg=str(e))
         except Exception as e:
             cgitb.Hook(format="text").handle(sys.exc_info())
             raise e


### PR DESCRIPTION
Create a resource with the same name with OpenContrail is not supported and raises a RefsExistError.
That patch catch that exception to raise a proper Neutron exception.

Signed-off-by: Édouard Thuleau edouard.thuleau@cloudwatt.com
