### PR TITLE
Fixes the bug introduced earlier when supporting multiple_ips for port

### DIFF
--- a/neutron_plugin_contrail/plugins/opencontrail/ctdb/config_db.py
+++ b/neutron_plugin_contrail/plugins/opencontrail/ctdb/config_db.py
@@ -2818,13 +2818,8 @@ class DBInterface(object):
         ip_objs = []
         if port_q['fixed_ips'] != attr.ATTR_NOT_SPECIFIED:
             for fixed_ip in port_q['fixed_ips']:
-                # subnet_id in fixed_ips is not yet supported.
-                # Raise a bad request 
-                if 'subnet_id' in fixed_ip:
-                    msg = _("fixed-ips doesn't support subnet id")
-                    raise exceptions.BadRequest(resource='subnet', msg=msg)
-
                 ip_dict = {'ip_obj' : None, 'ip_addr':None}
+
                 if 'ip_address' in fixed_ip:
                     ip_addr = fixed_ip['ip_address']
                     ip_dict['ip_addr'] = ip_addr


### PR DESCRIPTION
'neutron router-interface-add ' is failing. This pull request fixes it.
